### PR TITLE
Fix MacOS Clang 17+ compile issue

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -36,17 +36,17 @@ TARGET_ALIAS="dvp"
 TARG_XTRA_OPTS=""
 OSVER=$(uname)
 
-## If using MacOS Apple, set gmp and mpfr paths using TARG_XTRA_OPTS 
+## If using MacOS Apple, set gmp and mpfr paths using TARG_XTRA_OPTS
 ## (this is needed for Apple Silicon but we will do it for all MacOS systems)
 if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
-    TARG_XTRA_OPTS="--with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr)"
+    TARG_XTRA_OPTS="--with-system-zlib --with-gmp=$(brew --prefix gmp) --with-mpfr=$(brew --prefix mpfr)"
   elif command -v port &> /dev/null; then
   ## Check if using MacPorts
     MACPORT_BASE=$(dirname `port -q contents gmp|grep gmp.h`|sed s#/include##g)
     echo Macport base is $MACPORT_BASE
-    TARG_XTRA_OPTS="--with-gmp=$MACPORT_BASE --with-mpfr=$MACPORT_BASE"
+    TARG_XTRA_OPTS="--with-system-zlib --with-gmp=$MACPORT_BASE --with-mpfr=$MACPORT_BASE"
   fi
 fi
 


### PR DESCRIPTION
What this does
This patch fixes build issues on newer macOS systems (like Apple Silicon Macs running Clang 17 or higher).  It adds --with-system-zlib which avoids problems with fdopen() in zlib.

Why it's needed
Clang 17+ doesn’t play nice with the bundled zlib—it causes build errors because of a missing fdopen() macro. Using the system zlib fixes that.

Tested on
macOS Sonoma (M4 Mac Mini)

Homebrew + Clang 17+